### PR TITLE
Don't depend on Anaconda

### DIFF
--- a/ups/webservcommon.table
+++ b/ups/webservcommon.table
@@ -1,4 +1,3 @@
-setupRequired(anaconda)
 setupRequired(sconsUtils)
 
 envPrepend(LD_LIBRARY_PATH, ${PRODUCT_DIR}/lib)


### PR DESCRIPTION
We want to keep the stack buildable with any python 2.7, and should not explicitly depend on anaconda.
